### PR TITLE
Skip reactiveness for frozen data objects

### DIFF
--- a/src/tranjsform.js
+++ b/src/tranjsform.js
@@ -799,18 +799,18 @@ Tranjsform.DataFunction = function(data, locale, baseDir) {
 		this.properties[prop] = object[prop];
 
 		var self = this;
-		Object.defineProperty(object, prop, {
-		    get: function() { 
-		    	return self.properties[prop];
-		    },
-		    set: function f(value) { 
-		   		self.properties[prop] = value;
-		   		for (var c in self.callbacks) self.callbacks[c]();
-			}
-		});
-		
-
-
+		if ((!Object.seal || !Object.isSealed(object))
+		&& (!Object.freeze || !Object.isFrozen(object))) {
+			Object.defineProperty(object, prop, {
+				get: function() { 
+					return self.properties[prop];
+				},
+				set: function f(value) { 
+					self.properties[prop] = value;
+					for (var c in self.callbacks) self.callbacks[c]();
+				}
+			});
+		}
 	}
 };
 


### PR DESCRIPTION
In theory it doesn't make much sense to react to changes on an object that's frozen anyway, and trying to do so stops those objects from being used as data for Tranjsform, so make the reactiveness conditional on whether the object is frozen.
